### PR TITLE
New options keyword for more control over the 7za/7z command.

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -20,13 +20,14 @@ module.exports = function (archive, options) {
 
     var spec  = {};
     /* jshint maxlen: 130 */
-    var regex = /(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ([\.DA]+) +(\d+)[ \d]+  (.+)/;
+    var regex = /(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ([\.DA]+) +(\d+) +\d+ +(.+)/;
     /* jshint maxlen: 80 */
 
     // Create a string that can be parsed by `run`.
     var command = (/(rar)$/i.test(archive))? '7z ' : '7za ';
     command += 'l "' + archive + '" ';
 
+    var buffer = ""; //Store imcomplete line of a progress data. 
     // Start the command
     u.run(command, options)
 
@@ -35,7 +36,14 @@ module.exports = function (archive, options) {
     // pass it to an array. Finally returns this array.
     .progress(function (data) {
       var entries = [];
-      data.split('\n').forEach(function (line) {
+
+      //Last progress had an incomplete line. Prepend it to the data and clear buffer.
+      if(buffer.length > 0){
+        data = buffer + data;
+        buffer = "";
+      }//if
+
+      data.split('\n').forEach(function (line){
 
         // Populate the tech specs of the archive that are passed to the
         // resolve handler.
@@ -50,7 +58,6 @@ module.exports = function (archive, options) {
         } else if (line.substr(0, 15) === 'Headers Size = ') {
           spec.headersSize = parseInt(line.substr(15, line.length), 10);
         } else {
-
           // Parse the stdout to find entries
           var res = regex.exec(line);
           if (res) {
@@ -60,8 +67,9 @@ module.exports = function (archive, options) {
               size: parseInt(res[3], 10),
               name: res[4].replace(path.sep, '/')
             };
+
             entries.push(e);
-          }
+          }else buffer = line; //Line may be incomplete, Save it to the buffer.
 
         }
       });

--- a/util/switches.js
+++ b/util/switches.js
@@ -1,4 +1,5 @@
 'use strict';
+var util = require('util');
 
 /**
  * Transform an object of options into an array that can be passed to the
@@ -37,8 +38,9 @@ module.exports = function (switches) {
       // Special treatment for wilcards
       if (s === 'wildcards') {
         a.unshift(switches.wildcards);
-      }
-      else if (switches[s].indexOf(' ') === -1) {
+      }else if (s === 'raw' && util.isArray(switches.raw)){ //Allow raw switches to be added to the command, repeating switches like -i is not possible otherwise.
+        for(var i in switches.raw) a.push(switches.raw[i]);
+      } else if (switches[s].indexOf(' ') === -1) {
         a.push('-' + s + switches[s]);
       } else {
         a.push('-' + s + '"' + switches[s] + '"');


### PR DESCRIPTION
new array keyword "raw" added to options. this allows to add raw data to the switches, its needed when needing more control over 7zip. For example, if you want to only list out two file extensions you would need to put  -i!*.jpg -i!*.png on the command line, doing so with options {i:, i:} doesn't work since the repeat switch overrides the first one. When run without raw you only get png, but with raw I get a list of only png and jpgs. This will work with -x if you want to exclude more then one extension.

Its a very small change but its helpful for what I'm working on. Good library, written very well. Wasn't hard to find where I needed to make my changes. Thanks.