### PR TITLE
Add error handling when command not found

### DIFF
--- a/test/util/run.test.js
+++ b/test/util/run.test.js
@@ -71,7 +71,7 @@ describe('Utility: `run`', function () {
 
   it('should handle error when the command could not be found', function (done) {
     run('7zxxx a ".tmp/test/archive.7z" "*.exe" "*.dll"').catch(function (err) {
-      expect(err.message).to.eql('spawn 7zxxx ENOENT');
+      expect(err.message).to.contain('ENOENT');
       done();
     });
   });

--- a/test/util/run.test.js
+++ b/test/util/run.test.js
@@ -69,4 +69,11 @@ describe('Utility: `run`', function () {
     });
   });
 
+  it('should handle error when the command could not be found', function (done) {
+    run('7zxxx a ".tmp/test/archive.7z" "*.exe" "*.dll"').catch(function (err) {
+      expect(err.message).to.eql('spawn 7zxxx ENOENT');
+      done();
+    });
+  });
+
 });

--- a/util/run.js
+++ b/util/run.js
@@ -87,6 +87,9 @@ module.exports = function (command, switches) {
       }
       return progress(data.toString());
     });
+    run.on('error', function (err) {
+      reject(err)
+    });
     run.on('close', function (code) {
       if (code === 0) {
         return fulfill(args);


### PR DESCRIPTION
Hi, I have been creating a desktop application based on electron. 
I would like to handle error when 7z not found, which is useful when I want to let a user set the path for 7z.

I can urge the user to set the pass if I can know that a user cannot spawn 7zip beforehand.

Thanks.