### PR TITLE
Sometimes 7z does not include value in "Compressed" column, so the pr…

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -20,7 +20,7 @@ module.exports = function (archive, options) {
 
     var spec  = {};
     /* jshint maxlen: 130 */
-    var regex = /(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ([\.D][\.R][\.H][\.S][\.A]) +(\d+) +(\d+)? +(.+)/;
+    var regex = /(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ([\.DA]+)\s+(\d+)\s*(?:\d+)\s+(\S+?\.\S+)/; 
     /* jshint maxlen: 80 */
 
     // Create a string that can be parsed by `run`.


### PR DESCRIPTION
Hello,

In case there is nothing on the Compressed column on 7zip list output, the regex was failing to capture the filename on that line. So this change to make regex to prevent this difference to break the result.
