### PR TITLE
Return useful error from stderr

### DIFF
--- a/util/run.js
+++ b/util/run.js
@@ -87,6 +87,10 @@ module.exports = function (command, switches) {
       }
       return progress(data.toString());
     });
+    run.stderr.on('data', function (data) {
+      //throw errors
+		  err = data.toString();
+    });
     run.on('error', function (err) {
       reject(err)
     });


### PR DESCRIPTION
Instead of returning undefined error,  stderr can send more useful information.