### PR TITLE
Fix extracting to UNC paths

### DIFF
--- a/util/run.js
+++ b/util/run.js
@@ -47,7 +47,7 @@ module.exports = function (command, switches) {
       o = o.replace(/\//, path.sep);
       o = o.replace(/\\/, path.sep);
       o = o.replace(/"/g, '');
-      o = path.normalize(o);
+      o = "-o" + path.normalize(o.slice(2));
       args.push(o);
     }
 


### PR DESCRIPTION
Node-7z extractFull was failing to extract to UNC paths (e.g. //somemachine/somepath)

The path.normalize call was taking in a string such as "-o//somemachine/somepath" and converting it to "-o/somemachine/somepath"
Stripping off the -o prior to normalisation and then adding it back in fixes the problem.