### PR TITLE
no longer depend on regexp polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "named-regexp-groups": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/named-regexp-groups/-/named-regexp-groups-1.0.3.tgz",
+      "integrity": "sha512-sm+xkoA+d/lS4I7VMvM0f2fAmkrBEE2Ql1db0Q1iCdu3QINv4APM9o6Zo9XfD9aezH1vUQevCPypn+Aq+gTdtQ=="
+    },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
@@ -1583,11 +1588,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "regexp-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-polyfill/-/regexp-polyfill-1.0.1.tgz",
-      "integrity": "sha512-kyYqOUpy+/MYja6oXu8kNHO2f0BfN/7cb3X3xn2rRGDY8rUUsrti97+BO46TlTOhxDaY7t6AyFERue5x+ZRvcA=="
     },
     "rimraf": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "cross-spawn": "^6.0.4",
     "debug": "^4.1.1",
     "lodash": "^4.17.12",
-    "normalize-path": "^3.0.0",
-    "regexp-polyfill": "^1.0.1"
+    "named-regexp-groups": "^1.0.3",
+    "normalize-path": "^3.0.0"
   },
   "optionalDependencies": {},
   "devDependencies": {

--- a/src/regexp.js
+++ b/src/regexp.js
@@ -1,13 +1,13 @@
-// @COMPAT Named capture groups aren't available before Node.js 10. This
-// compatibility checks the running Node.js version and apply a polyfill
-// if needed.
+// @COMPAT Named capture groups aren't available before Node.js 10.
 // Support until Jan 2020 (https://github.com/nodejs/Release)
-const semver = /v(\d+)\.(\d+)\.(\d+)/
-const nodeVersionResults = process.version.match(semver)
-const nodeVersionMajor = parseInt(nodeVersionResults[1])
-if (nodeVersionMajor < 10) {
-  require('regexp-polyfill')
-}
+const RegExp = (() => {
+  try {
+    new RegExp('(?<test>a)')
+    return RegExp
+  } catch (error) {
+    return require('named-regexp-groups')
+  }
+})()
 
 const LINE_SPLIT = new RegExp('\n|\r\n|\x08+|\r +\r')
 const BODY_PROGRESS = new RegExp('^ *(?<percent>\\d+)% ?(?<fileCount>\\d+)? ?(?<file>.*)$')

--- a/src/regexp.js
+++ b/src/regexp.js
@@ -2,7 +2,7 @@
 // Support until Jan 2020 (https://github.com/nodejs/Release)
 const RegExp = (() => {
   try {
-    new RegExp('(?<test>a)')
+    new RegExp('(?<test>a)') // eslint-disable-line no-new
     return RegExp
   } catch (error) {
     return require('named-regexp-groups')


### PR DESCRIPTION
#69 Uses a local reference for named groups rather than dangerously modifying the global RegExp object.