### PR TITLE
docs: Fix options table parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ In the 7-Zip world, command flags are called switches. In order to use them you 
 | `hashMethod`             | `string`   | Set hash function                                                     | `-scrc`  |
 | `listFileCharset`        | `string`   | Set charset for list files                                            | `-scs`   |
 | `logLevel`               | `string`   | Set output log level                                                  | `-bb`    |
-| `multiBlockSize`         | `string`   | Creates multi-block xz archives of `[Size]m|g` block size             | `-ms`    |
+| `multiBlockSize`         | `string`   | Creates multi-block xz archives of `[Size]m\|g` block size             | `-ms`    |
 | `outputDir`              | `string`   | Set Output directory                                                  | `-o`     |
 | `overwrite`              | `string`   | Overwrite mode                                                        | `-ao`    |
 | `password`               | `string`   | Set Password                                                          | `-p`     |


### PR DESCRIPTION
Hello,

This is a quick documentation fix on the `options` table. The option to specify the size of the various chunks was badly transformed by GitHub markdown parser.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/283419/124281042-a0b14600-db49-11eb-947d-09f1d89c8ddf.png)| ![image](https://user-images.githubusercontent.com/283419/124281144-b7f03380-db49-11eb-9307-f684a109002d.png) |
