### PR TITLE
fix: spawn options are processed

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/quentinrossetti/node-7z.git"
+    "url": "https://github.com/jliben/node-7z.git"
   },
   "keywords": [
     "node",
@@ -27,7 +27,9 @@
     "wrapper"
   ],
   "author": "Quentin Rossetti <quentin.rossetti@gmail.com>",
-  "contributors": [],
+  "contributors": [
+    {"name": "Jessé LIBEN", "email": "jliben@gmail.com"}
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/quentinrossetti/node-7zip/issues"

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -51,6 +51,7 @@ export const createFactory = ({
   seven._dataType = Parser.fetch(options._command, 'dataType')
   seven._matchInfos = Parser.matchInfos
   seven._matchProgress = Parser.matchProgress
+  seven._spawnOptions = options.$spawnOptions
   seven.info = new Map()
   debug('lifecycle: create %O', options)
   return seven

--- a/test/unit/lifecycle.spec.js
+++ b/test/unit/lifecycle.spec.js
@@ -45,6 +45,21 @@ describe('Unit: lifecycle.js', function () {
       expect(sevenFake._stage).to.eql(STAGE_HEADERS)
     })
 
+    it.only('should handle $spawnOptions', function () {
+      const create = Seven.createFactory({
+        Bin: binFromOptionsFake,
+        Flags: flagsFromOptionsFake,
+        Parser: parserFake,
+        Args: argsFromOptionsFake
+      })
+      const sevenFake = create({
+        $spawnOptions: {
+          background: false
+        }
+      })
+      expect(sevenFake._spawnOptions.background).to.eql(false)
+    })
+
     it('should set _isProgressFlag when specified', function () {
       const create = Seven.createFactory({
         Bin: binFromOptionsFake,

--- a/test/unit/lifecycle.spec.js
+++ b/test/unit/lifecycle.spec.js
@@ -45,7 +45,7 @@ describe('Unit: lifecycle.js', function () {
       expect(sevenFake._stage).to.eql(STAGE_HEADERS)
     })
 
-    it.only('should handle $spawnOptions', function () {
+    it('should handle $spawnOptions', function () {
       const create = Seven.createFactory({
         Bin: binFromOptionsFake,
         Flags: flagsFromOptionsFake,


### PR DESCRIPTION
While using this nice lib to compress a pretty big folder, I realized that the child_process is spawned as a background process.
On my (windows) machine, this leads to the 7za child to continue running when I interrupt the node.js program that spawned it.

I think it would make sense to default the `detached` option of the child_process to false, however, in order to keep background compatibility, I tried to use the documented $spawnOptions, like so:
```js
      const compressStream = add(
        path.resolve(RELEASE_DIR, "archive.7z"),
        ".",
        {
          $bin: sevenBin.path7za,
          $progress: true,
          $spawnOptions: {
            detached: false,
          },
        }
      )
```

Just realised it was not processed, so I'm submitting this little fix to support it.

Basic unit tests added as well, I could not really figure out how to write more advanced integration tests.