### PR TITLE
fix: stderr bug #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "author": "Quentin Rossetti <quentin.rossetti@gmail.com>",
   "contributors": [
-    {"name": "Jessé LIBEN", "email": "jliben@gmail.com"}
+    {"name": "Jessé LIBEN", "email": "jliben@gmail.com"},
+    {"name": "Daniel Amado", "email": "velkan14@gmail.com"}
   ],
   "license": "ISC",
   "bugs": {

--- a/src/error.js
+++ b/src/error.js
@@ -24,6 +24,16 @@ export const assign = (stream, err) => {
   return stream
 }
 
+// Just append the buffer to the stream. The error is created before emitting on close
+export const append = (stream, buffer) => {
+  if (stream.stderr) {
+    stream.stderr += buffer
+  } else {
+    stream.stderr = buffer
+  }
+  return stream
+}
+
 export const fromBuffer = chunk => {
   const stderr = chunk.toString()
   const match = stderr.match(ERROR)
@@ -36,4 +46,4 @@ export const fromBuffer = chunk => {
   return err
 }
 
-export default { assign, fromBuffer }
+export default { append, assign, fromBuffer }

--- a/src/events.js
+++ b/src/events.js
@@ -23,9 +23,8 @@ export const onErrorFactory = ({ Err }) => (stream, err) => {
 }
 
 export const onStderrFactory = ({ Err }) => (stream, buffer) => {
-  const err = Err.fromBuffer(buffer)
-  Err.assign(stream, err)
-  debug('error: from stderr: %O', err)
+  Err.append(stream, buffer)
+  debug('error: append from stderr: %O', buffer)
   return stream
 }
 
@@ -88,7 +87,12 @@ export const onStdoutFactory = ({ Maybe }) => (stream, chunk) => {
   return stream
 }
 
-export const onEndFactory = () => (stream) => {
+export const onEndFactory = ({ Err }) => (stream) => {
+  if (stream.stderr) {
+    const err = Err.fromBuffer(stream.stderr)
+    Err.assign(stream, err)
+    debug('error: from stderr: %O', err)
+  }
   if (stream.err) {
     stream.emit('error', stream.err)
   }

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ const listenFactory = ({ Lifecycle, Err, Maybe }) => seven => {
     errorHandler: onErrorFactory({ Err }),
     stderrHandler: onStderrFactory({ Err }),
     stdoutHandler: onStdoutFactory({ Maybe }),
-    endHandler: onEndFactory()
+    endHandler: onEndFactory({ Err })
   })(seven)
   return seven
 }


### PR DESCRIPTION
This is a fix that should fix bug #121 .

`onStderrFactory` we are appending the buffer to the stream and only on `onEndFactory` we create the error if we have the buffer in the stream. 
This way we are able to match the error properly, because every part of the `stderr `will be available for the `match`. 